### PR TITLE
chore: fix the `Project Manage` URL error

### DIFF
--- a/doc/0manage/nexmaker-academy.html
+++ b/doc/0manage/nexmaker-academy.html
@@ -193,7 +193,7 @@
     
         <li class="chapter " data-level="2.1" >
             
-                <a target="_blank" href="https://git-scm.com/">
+                <a target="_blank" href="../1projectmanage/Assessment1.html">
             
                     
                     1.Project manage


### PR DESCRIPTION
![image](https://github.com/NexMaker-Fab/guide-book/assets/51821219/44cabd2e-a7ec-42f7-9100-befca00ddd1d)
